### PR TITLE
disable play hand and discard buttons when no cards are selected

### DIFF
--- a/resources/js/Pages/Game.vue
+++ b/resources/js/Pages/Game.vue
@@ -28,9 +28,7 @@ const props = defineProps<{
     totalPoints: number;
 }>();
 
-const isButtonDisabled = () => {
-    return gameStore.selectedCards.length === 0;
-};
+const isButtonDisabled = computed(() => gameStore.selectedCards.length === 0);
 </script>
 
 <template>
@@ -74,10 +72,10 @@ const isButtonDisabled = () => {
 
                         <div class="flex gap-3">
                             <button
-                                :disabled="isButtonDisabled()"
+                                :disabled="isButtonDisabled"
                                 :class="{
                                     'opacity-50 cursor-not-allowed':
-                                        isButtonDisabled(),
+                                        isButtonDisabled,
                                 }"
                                 class="mt-6 px-4 py-2 text-white bg-indigo-600 rounded-md hover:bg-indigo-700"
                                 @click="gameStore.showScore"
@@ -85,10 +83,10 @@ const isButtonDisabled = () => {
                                 Play Hand
                             </button>
                             <button
-                                :disabled="isButtonDisabled()"
+                                :disabled="isButtonDisabled"
                                 :class="{
                                     'opacity-50 cursor-not-allowed':
-                                        isButtonDisabled(),
+                                        isButtonDisabled,
                                 }"
                                 class="mt-6 px-4 py-2 text-white bg-red-600 rounded-md hover:bg-indigo-700"
                                 @click="gameStore.discardCards"


### PR DESCRIPTION
Added opacity and cursor-not-allowed to Play Hand and Discard buttons when no cards are selected.

Closes #106 