### PR TITLE
added cards from hand to total

### DIFF
--- a/resources/js/Components/PlayedCards.vue
+++ b/resources/js/Components/PlayedCards.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { useGameStore } from "@/stores/game";
+
+const gameStore = useGameStore();
+</script>
+
+<template>
+    <div class="mb-20 relative">
+        <ul class="flex gap-3 mb-20">
+            <li
+                v-for="(card, index) in gameStore.playableCards"
+                :key="index"
+                class="flex flex-col relative"
+            >
+                <p
+                    class="flex justify-center mb-3"
+                    v-if="index === gameStore.currentCardIndex"
+                >
+                    {{ card.value }}
+                </p>
+                <div class="h-20 w-20 flex items-center justify-center">
+                   <img
+                    :src="`../card_svgs/${card.name}.svg`"
+                    :alt="card.name"
+                    class="flex mt-10"
+                /> 
+                </div>
+                
+            </li>
+        </ul>
+    </div>
+</template>

--- a/resources/js/Pages/Game.vue
+++ b/resources/js/Pages/Game.vue
@@ -10,6 +10,7 @@ import HandSort from "@/Components/HandSort.vue";
 import GameScore from "@/Components/GameScore.vue";
 import HandsAndDiscards from "@/Components/HandsAndDiscards.vue";
 import CashAndTotalPoints from "@/Components/CashAndTotalPoints.vue";
+import PlayedCards from "@/Components/PlayedCards.vue";
 
 const gameStore = useGameStore();
 
@@ -47,6 +48,8 @@ const isButtonDisabled = computed(() => gameStore.selectedCards.length === 0);
                         :showPlayerHand="gameStore.showPlayerHand"
                     />
 
+                    <PlayedCards v-if="gameStore.isPlayHandClicked"/>
+
                     <div class="flex flex-col items-center">
                         <draggable
                             class="flex justify-center gap-3 list-none"
@@ -54,19 +57,23 @@ const isButtonDisabled = computed(() => gameStore.selectedCards.length === 0);
                             :item-key="(item) => item.id"
                         >
                             <template #item="{ element }">
-                                <li
-                                    :key="element"
-                                    class="card"
-                                    :class="{
-                                        selected: gameStore.isSelected(element),
-                                    }"
-                                    @click="gameStore.toggleCard(element)"
-                                >
-                                    <img
-                                        :src="`../card_svgs/${element.name}.svg`"
-                                        :alt="element.name"
-                                    />
-                                </li>
+                                <div>
+                                    <li
+                                        :key="element"
+                                        class="card"
+                                        :class="{
+                                            selected:
+                                                gameStore.isSelected(element),
+                                        }"
+                                        @click="gameStore.toggleCard(element)"
+                                    >
+                                        <img
+                                            :src="`../card_svgs/${element.name}.svg`"
+                                            :alt="element.name"
+                                            class="flex"
+                                        />
+                                    </li>
+                                </div>
                             </template>
                         </draggable>
 

--- a/resources/js/composables/__tests__/hand-calculator.spec.js
+++ b/resources/js/composables/__tests__/hand-calculator.spec.js
@@ -118,7 +118,7 @@ describe('Hand calculator test suite', () => {
     });
 
     it('should return royalFlush when the only applicable card is that', () => {
-            const straightFlushHand = [
+            const royalFlushHand = [
                 { value: 11, suit: 'hearts', rank: 14 },
                 { value: 10, suit: 'hearts', rank: 13 },
                 { value: 10, suit: 'hearts', rank: 12 },
@@ -126,7 +126,7 @@ describe('Hand calculator test suite', () => {
                 { value: 10, suit: 'hearts', rank: 10 },
             ];
     
-            const result = getHandName(straightFlushHand);
-            expect(result).toEqual('straightFlush');
+            const result = getHandName(royalFlushHand);
+            expect(result).toEqual('royalFlush');
     });
 });

--- a/resources/js/composables/hand-calculator.js
+++ b/resources/js/composables/hand-calculator.js
@@ -6,21 +6,24 @@ export function useHandCalculator() {
     // All of the functions below should return a boolean value, true if the hand is that type, false otherwise.
 
     const sortCards = (cards) => cards.sort((a, b) => a.rank - b.rank);
-    const lowAceCheck = (cards) => {
-        if (
-            cards.length === 5 &&
-            cards[4].rank === 14 &&
-            cards[0].rank === 2 &&
-            cards[1].rank === 3 &&
-            cards[2].rank === 4 &&
-            cards[3].rank === 5
-        ) {
-            return true;
-        }
-    };
+    // const lowAceCheck = (cards) => {
+    //     if (
+    //         cards.length === 5 &&
+    //         cards[4].rank === 14 &&
+    //         cards[0].rank === 2 &&
+    //         cards[1].rank === 3 &&
+    //         cards[2].rank === 4 &&
+    //         cards[3].rank === 5
+    //     ) {
+    //         return true;
+    //     }
+    // };
+
+    let playableCards = [];
 
     const countNumOfEachRank = (cards, number) => {
         const rankCounts = {};
+
         for (const card of cards) {
             if (rankCounts[card.rank]) {
                 rankCounts[card.rank] += 1;
@@ -28,8 +31,14 @@ export function useHandCalculator() {
                 rankCounts[card.rank] = 1;
             }
         }
+
         for (const rank in rankCounts) {
             if (rankCounts[rank] === number) {
+                for (const card of cards) {
+                    if (card.rank === Number(rank)) {
+                        playableCards.push(card);
+                    }
+                }
                 return true;
             }
         }
@@ -50,12 +59,15 @@ export function useHandCalculator() {
 
         if (
             cards.length === 5 &&
-            cards[0].rank === 14 &&
-            cards[1].rank === 13 &&
-            cards[2].rank === 12 &&
-            cards[3].rank === 11 &&
-            cards[4].rank === 10
+            cards[0].rank == 10 &&
+            cards[1].rank == 11 &&
+            cards[2].rank == 12 &&
+            cards[3].rank == 13 &&
+            cards[4].rank == 14
         ) {
+            for (const card of cards) {
+                playableCards.push(card);
+            }
             return true;
         }
         return false;
@@ -68,13 +80,26 @@ export function useHandCalculator() {
         }
         sortCards(cards);
 
-        lowAceCheck(cards);
+        //lowAceCheck()
+        if (
+            cards.length === 5 &&
+            cards[4].rank === 14 &&
+            cards[0].rank === 2 &&
+            cards[1].rank === 3 &&
+            cards[2].rank === 4 &&
+            cards[3].rank === 5
+        ) {
+            return true;
+        }
 
         if (cards.length === 5) {
             for (let i = 1; i < cards.length; i++) {
                 if (cards[i].rank !== cards[i - 1].rank + 1) {
                     return false;
                 }
+            }
+            for (const card of cards) {
+                playableCards.push(card);
             }
             return true;
         }
@@ -113,25 +138,53 @@ export function useHandCalculator() {
                 }
             }
         }
+        if (fullHouse) {
+            for (const card of cards) {
+                playableCards.push(card);
+            }
+        }
+
         return fullHouse;
     };
 
     // Flush: Five cards of the same suit, not in sequence
-    const isFlush = (cards) =>
-        cards.every((card) => card.suit === cards[0].suit) &&
-        cards.length === 5;
+    const isFlush = (cards) => {
+        if (
+            cards.every((card) => card.suit === cards[0].suit) &&
+            cards.length === 5
+        ) {
+            for (const card of cards) {
+                playableCards.push(card);
+            }
+            return true;
+        }
+        return false;
+    };
 
     // Straight: Five cards in a sequence, but not of the same suit.
     const isStraight = (cards) => {
         sortCards(cards);
 
-        lowAceCheck(cards);
+        //lowAceCheck();
+        if (
+            cards.length === 5 &&
+            cards[4].rank === 14 &&
+            cards[0].rank === 2 &&
+            cards[1].rank === 3 &&
+            cards[2].rank === 4 &&
+            cards[3].rank === 5
+        ) {
+            return true;
+        }
 
         if (cards.length === 5) {
             for (let i = 1; i < cards.length; i++) {
                 if (cards[i].rank !== cards[i - 1].rank + 1) {
                     return false;
                 }
+            }
+            for (const card of cards) {
+                playableCards.push(card);
             }
             return true;
         }
@@ -155,11 +208,15 @@ export function useHandCalculator() {
         }
 
         let pairs = 0;
-        for (const key in rankCounts) {
-            if (rankCounts[key] === 2) {
+        for (const rank in rankCounts) {
+            if (rankCounts[rank] === 2) {
                 pairs++;
 
                 if (pairs === 2) {
+                    for (const card of cards) {
+                        if (rankCounts[card.rank] === 2)
+                            playableCards.push(card);
+                    }
                     return true;
                 }
             }
@@ -169,8 +226,13 @@ export function useHandCalculator() {
 
     // Pair: Two cards of the same rank
     const isPair = (cards) => {
-        return countNumOfEachRank(cards, 2)
+        return countNumOfEachRank(cards, 2);
     };
+
+    // const isHighCard = (cards) => {
+    //     sortCards(cards)
+    //     playableCards.push(cards[cards.length-1])
+    // }
 
     const getHandName = (cards) => {
         if (isFiveOfAKind(cards)) {
@@ -194,6 +256,7 @@ export function useHandCalculator() {
         } else if (isPair(cards)) {
             return "pair";
         } else if (cards.length >= 1) {
+            playableCards.push(cards[cards.length - 1]);
             return "highCard";
         } else {
             return "noCards";
@@ -202,6 +265,7 @@ export function useHandCalculator() {
 
     return {
         getHandName,
+        playableCards,
     };
 }
 


### PR DESCRIPTION
When cards are selected and Play Hand is clicked, cards that form a hand are shown above. One by one, the values of those cards are added to the score. 
The score x multiplier is not yet calculated.

Fixed a bug with Royal Flush

Some issues to fix:
The selected cards that do not make up the hand disappear.
The elements move when Play Hand is clicked and values are displayed. 
LowAceCheck in hand-calculator is not working. 